### PR TITLE
Fall back to recent song when listening to a podcast

### DIFF
--- a/api/spotify.py
+++ b/api/spotify.py
@@ -39,7 +39,7 @@ def refreshToken():
 
     headers = {"Authorization": "Basic {}".format(getAuth())}
     response = requests.post(REFRESH_TOKEN_URL, data=data, headers=headers)
-    
+
     try:
         return response.json()["access_token"]
     except KeyError:
@@ -92,7 +92,7 @@ def makeSVG(data):
     contentBar = "".join(["<div class='bar'></div>" for i in range(barCount)])
     barCSS = barGen(barCount)
 
-    if data == {} or data["item"] == "None":
+    if data == {} or data["item"] == "None" or data["item"] is None:
         # contentBar = "" #Shows/Hides the EQ bar if no song is currently playing
         currentStatus = "Was playing:"
         recentPlays = recentlyPlayed()


### PR DESCRIPTION
When I'm listening to a podcast on Spotify, the app crashes with this error:

```
[ERROR]	2020-12-17T23:25:33.754Z	86f19ec4-d42b-43e7-855b-5f5c08a6157f	Exception on /api/spotify [GET]
Traceback (most recent call last):
  File "/var/task/flask/app.py", line 2447, in wsgi_app
    response = self.full_dispatch_request()
  File "/var/task/flask/app.py", line 1952, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/var/task/flask/app.py", line 1821, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/var/task/flask/_compat.py", line 39, in reraise
    raise value
  File "/var/task/flask/app.py", line 1950, in full_dispatch_request
    rv = self.dispatch_request()
  File "/var/task/flask/app.py", line 1936, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "./api/spotify.py", line 125, in catch_all
    svg = makeSVG(data)
  File "./api/spotify.py", line 105, in makeSVG
    image = loadImageB64(item["album"]["images"][1]["url"])
TypeError: 'NoneType' object is not subscriptable
```

The result is that the README displays a broken image link ![](https://jpc.io/r/error.jpg)

The cause? The `data` dictionary is structured like this:

```
{'timestamp': 1608247800004, 'context': None, 'progress_ms': 1550756, 'item': None, 'currently_playing_type': 'episode', 'actions': {'disallows': {'resuming': True, 'toggling_shuffle': True}}, 'is_playing': True}
```

There is already a check for `data["item"] == "None"` but there was no check for `data["item"] is None`. 

This commit adds that check.