### PR TITLE
[added] css style for cover image as rotating disc

### DIFF
--- a/api/templates/spotify.html.j2
+++ b/api/templates/spotify.html.j2
@@ -51,7 +51,8 @@
                 .cover {
                     width: 100px;
                     height: 100px;
-                    border-radius: 5px;
+                    border-radius: 50%;
+                    animation: disc 16s linear infinite;
                 }
 
                 #bars {
@@ -84,6 +85,16 @@
                     100% {
                         height: 15px;
                         opacity: 0.95;
+                    }
+                }
+
+                @keyframes disc {
+                    from {
+                        transform: rotate(0deg);
+                    }
+
+                    to {
+                        transform: rotate(360deg);
                     }
                 }
 


### PR DESCRIPTION
#### 👉 Added following css changes

1. Cover image border radius - 50%
2. Disc animation key frames

#### 🎥 Preview changes:
<img src="https://media.giphy.com/media/gGa9Ezf2fMSU22wSGR/giphy.gif" />