### PR TITLE
requests==2.28.1 and urllib3==1.26.12

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ certifi==2020.6.20
 chardet==3.0.4
 click==7.1.2
 Flask==1.1.4
-gunicorn==20.1.0
+gunicorn==22.0.0
 idna==2.10
 itsdangerous==1.1.0
 Jinja2==2.11.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,8 +10,8 @@ Jinja2==2.11.3
 MarkupSafe==2.0.1
 pycodestyle==2.8.0
 python-dotenv==0.14.0
-requests==2.24.0
+requests==2.28.1
 toml==0.10.2
-urllib3==1.25.11
+urllib3==1.26.12
 Werkzeug==1.0.1
 colorthief==0.2.1


### PR DESCRIPTION
### **To solve Vercel deployment issue**

older versions in requirements.txt are causing deployment issues for serverless function on vercel.

To solve the issue - 

_**requests==2.28.1
urllib3==1.26.12**_

these need to be updated to respective versions!