### PR TITLE
Fix vercel deployment detection

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -1,0 +1,2 @@
+# app.py
+from api.orchestrator import app


### PR DESCRIPTION
Hey there!
I noticed a issue while deploying novatorem (Spotify) on Vercel. 
Vercel throws the following error on trying to deploying the project:
` app.py not found `
This pull request has only one commit, which is adding one file. 
The file is app.py which basically imports app from orchestrator for Vercel to successfully deploy.
Do keep in mind the readme reference syntax will be the same. 
This file is only for Vercel to deploy correctly and does not change anything. 